### PR TITLE
Update the cuDNN version from 8.5 to 8.7 for cuda 11.8

### DIFF
--- a/install_cuda.sh
+++ b/install_cuda.sh
@@ -26,10 +26,10 @@ if [ "$t_cuda" == "117" ] ; then
 fi
 if [ "$t_cuda" == "118" ] ; then
     cuda_download_link="https://developer.download.nvidia.com/compute/cuda/11.8.0/local_installers/cuda_11.8.0_520.61.05_linux.run"
-    cudnn_download_link="https://ossci-linux.s3.amazonaws.com/cudnn-linux-x86_64-8.5.0.96_cuda11-archive.tar.xz"
+    cudnn_download_link="https://developer.download.nvidia.com/compute/redist/cudnn/v8.7.0/local_installers/11.8/cudnn-linux-x86_64-8.7.0.84_cuda11-archive.tar.xz"
     cuda_file_name="cuda_11.8.0_520.61.05_linux.run"
-    cudnn_file_name="cudnn-linux-x86_64-8.5.0.96_cuda11-archive"
-    cudnn_file_name_with_ext="cudnn-linux-x86_64-8.5.0.96_cuda11-archive.tar.xz"
+    cudnn_file_name="cudnn-linux-x86_64-8.7.0.84_cuda11-archive"
+    cudnn_file_name_with_ext="cudnn-linux-x86_64-8.7.0.84_cuda11-archive.tar.xz"
 fi
 if [ -z "$cuda_download_link" ]; then
     echo "t_cuda is only available for 116, 117, 118"

--- a/install_cuda.sh
+++ b/install_cuda.sh
@@ -26,10 +26,17 @@ if [ "$t_cuda" == "117" ] ; then
 fi
 if [ "$t_cuda" == "118" ] ; then
     cuda_download_link="https://developer.download.nvidia.com/compute/cuda/11.8.0/local_installers/cuda_11.8.0_520.61.05_linux.run"
+    cudnn_download_link="https://ossci-linux.s3.amazonaws.com/cudnn-linux-x86_64-8.5.0.96_cuda11-archive.tar.xz"
+    cuda_file_name="cuda_11.8.0_520.61.05_linux.run"
+    cudnn_file_name="cudnn-linux-x86_64-8.5.0.96_cuda11-archive"
+    cudnn_file_name_with_ext="cudnn-linux-x86_64-8.5.0.96_cuda11-archive.tar.xz"
+fi
+if [ "$t_cuda" == "1187" ] ; then
+    cuda_download_link="https://developer.download.nvidia.com/compute/cuda/11.8.0/local_installers/cuda_11.8.0_520.61.05_linux.run"
     cudnn_download_link="https://developer.download.nvidia.com/compute/redist/cudnn/v8.7.0/local_installers/11.8/cudnn-linux-x86_64-8.7.0.84_cuda11-archive.tar.xz"
     cuda_file_name="cuda_11.8.0_520.61.05_linux.run"
     cudnn_file_name="cudnn-linux-x86_64-8.7.0.84_cuda11-archive"
-    cudnn_file_name_with_ext="cudnn-linux-x86_64-8.7.0.84_cuda11-archive.tar.xz"
+    cudnn_file_name_with_ext=$cudnn_file_name."tar.xz"
 fi
 if [ -z "$cuda_download_link" ]; then
     echo "t_cuda is only available for 116, 117, 118"


### PR DESCRIPTION
1. Add new option `t_cuda=1187` to install the up-to-date cuDNN 8.7 compatible with CUDA 11.8.
2. Change the cuDNN source from [~~ossci-linux.s3.amazonaws.com~~](https://ossci-linux.s3.amazonaws.com/) to [NVIDIA's official cuDNN archive source](https://developer.download.nvidia.com/compute/redist/cudnn).